### PR TITLE
Upgrade maven install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+.project
+.classpath
+org.eclipse.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
 .project
 .classpath
-org.eclipse.*
+.settings
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: java
+dist: trusty
+sudo: true
+
+matrix:
+  include:      
+    #Linux
+    - os: linux
+    
+    # OSX
+    - os: osx
+      sudo: false
+
+# jdk_switcher does not work on OSX so only use if Linux
+before_install:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then jdk_switcher use "oraclejdk8"; fi
+
+script:
+  - mvn compile
+  - mvn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,3 @@ before_install:
 script:
   - mvn compile
   - mvn test
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ before_install:
 script:
   - mvn compile
   - mvn test
+  

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
So that we can install the diffblue.jar in the 'simplest' way (i.e. by maven finding the pom.xml within) we should use the latest version of the maven install plugin.

As a side effect of this I have updated the gitignore and also enabled travis builds.