### PR TITLE
Remove redundant maven-install plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <version>2.5.2</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>2.17</version>
         <executions>


### PR DESCRIPTION
This is no longer needed since `deeptestutils` is pulled in from Maven Central.