### PR TITLE
Reinstate java-max-input-array-length

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,0 +1,4 @@
+cbmcArguments:
+  # Because tic-tac-toe has 9 squares, we need to unwind the loops 10 times
+  # This will be auto-detected in a future version
+  java-max-input-array-length: 10


### PR DESCRIPTION
The need to increase this is still not detected by default.