### PR TITLE
Add ignoreExistingCoverage true

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,3 +1,4 @@
+ignoreExistingCoverage: true
 cbmcArguments:
   # Because tic-tac-toe has 9 squares, we need to unwind the loops 10 times
   # This will be auto-detected in a future version


### PR DESCRIPTION
The project has a couple of tests that cover ~10% of the code. To generate 100% coverage for Java Demo on dashboard, we need this option. Previously, it was not needed to have this option explicitly set in this file because dashboard was setting it by default. This is no longer true due to a recent platform API change.