### PR TITLE
Load fat jar but do not analyse dependencies [TG-9521]

### DIFF
--- a/diffblue.yml
+++ b/diffblue.yml
@@ -1,5 +1,0 @@
-ignoreExistingCoverage: true
-cbmcArguments:
-  # Because tic-tac-toe has 9 squares, we need to unwind the loops 10 times
-  # This will be auto-detected in a future version
-  max-nondet-array-length: 10

--- a/difflue-base.json
+++ b/difflue-base.json
@@ -1,0 +1,21 @@
+{
+  "phaseBase": {
+    "preferDepsJar": true,
+    "context-include": [
+      "com.diffblue.javademo.",
+      "com.diffblue.annotation.",
+      "java.",
+      "org.cprover.",
+      "org.slf4j.helpers.MarkerIgnoringBase",
+      "org.slf4j.helpers.NamedLoggerBase",
+      "org.slf4j.helpers.NOPLogger",
+      "org.slf4j.ILoggerFactory",
+      "org.slf4j.Logger",
+      "org.slf4j.LoggerFactory",
+      "org.slf4j.Marker",
+      "sun.misc.",
+      "sun.nio.cs.",
+      "sun.util."
+    ]
+  }
+}


### PR DESCRIPTION
Branch used for analysis for this benchmark is fat-jar, see https://diffblue.atlassian.net/wiki/spaces/DOC/pages/51282069/Dashboard+benchmarks

With all dependencies on the classpath but "context-excluded", we expect the coverage to be the same as before after this change, and the analysis time should not be much longer.